### PR TITLE
Fix OpenMC Torus parameters definition

### DIFF
--- a/src/GEOUNED/Write/Functions.py
+++ b/src/GEOUNED/Write/Functions.py
@@ -478,7 +478,7 @@ def OpenMCSurface(Type,surf,outXML=True,quadricForm=False):
                                                                      surf.MajorRadius, surf.MinorRadius, surf.MinorRadius,\
                                                                      xyz=nf.T_xyz,r=nf.T_r)     
         else:
-           coeffs ='x0={},y0={},z0={},r{},r1={},r2={}'.format(surf.Center.x, surf.Center.y, surf.Center.z, surf.MajorRadius, surf.MinorRadius, surf.MinorRadius)
+           coeffs ='x0={},y0={},z0={},a={},b={},c={}'.format(surf.Center.x, surf.Center.y, surf.Center.z, surf.MajorRadius, surf.MinorRadius, surf.MinorRadius)
 
         if (isParallel(Dir,FreeCAD.Vector(1,0,0),tol.angle)):
              OMCsurf = 'x-torus' if outXML else 'XTorus'


### PR DESCRIPTION
Torus inputs for OpenMC were failing because the keywords of the parameters must be a, b and c rather than r, r1 and r2. Additionally, an "=" sign was missing.