### PR TITLE
Update parser.py - fix for mphys and mx cards

### DIFF
--- a/src/GEOReverse/Modules/Parser/parser.py
+++ b/src/GEOReverse/Modules/Parser/parser.py
@@ -1094,7 +1094,8 @@ def _split_data(input_):
         fmts.append(fmt_d(ns))
     elif (t[0][0].lower() == 'm' and
           'mode' not in t[0].lower() and
-          'mesh' not in t[0].lower()):
+          'mesh' not in t[0].lower() and
+          'mphys' not in t[0].lower()):
         # This is the Mn, MTn or MPNn card
         ms = _get_int(t[0])
         inpt = inpt.replace(ms, tp, 1)
@@ -1107,6 +1108,8 @@ def _split_data(input_):
             dtype = 'MTn'
         elif t[0][1].lower() == 'p':
             dtype = 'MPNn'
+        elif t[0][1].lower() == 'x':
+            dtype = 'MXn'
     elif t[0][0].lower() == 'f' and t[0][1].isdigit():
         # FN card
         dtype = 'Fn'


### PR DESCRIPTION


fixes a dtype used before allocated error for extra data cards starting with "m".
Followed the existing pattern with none materials related cards (mphys) added to the if statement and material related (mx) card added a seperate dtype allocation.

There possibly should be a final else clause with dtype = None to catch any other data cards starting with m that are not dealt with already.