### PR TITLE
Removed unused imports and variables

### DIFF
--- a/src/GEOUNED/Cuboid/translate.py
+++ b/src/GEOUNED/Cuboid/translate.py
@@ -1,7 +1,7 @@
 from    GEOUNED.Utils.booleanFunction import BoolSequence
 import GEOUNED.Utils.Geometry_GU as GU
 from   GEOUNED.Utils.BasicFunctions_part1  \
-       import isParallel, isOposite, isInLine, signPlane, isSameValue
+       import isParallel, isOposite
 import  GEOUNED.Utils.BasicFunctions_part2 as BF
 import GEOUNED.Decompose.Decom_one as Decom
 from GEOUNED.Utils.Options.Classes import Tolerances as tol
@@ -49,8 +49,6 @@ def isInverted(solid):
     u=(Range[1]+Range[0])/2.0
     v=(Range[3]+Range[2])/2.0
 
-    dist1=face.CenterOfMass.distanceToPoint(solid.BoundBox.Center)
-    dist2=face.CenterOfMass.add(face.normalAt(u,v).multiply(1.0e-6)).distanceToPoint(solid.BoundBox.Center)
     point2=face.CenterOfMass.add(face.normalAt(u,v).multiply(1.0e-6))
 
     if (solid.isInside(point2,1e-7,False)):
@@ -61,7 +59,6 @@ def isInverted(solid):
 
 def getId(facein, Surfaces):
     
-    surfin = str(facein)
     if   isParallel(facein.Axis,FreeCAD.Vector(1,0,0),tol.pln_angle) :
        P = 'PX'
     elif isParallel(facein.Axis,FreeCAD.Vector(0,1,0),tol.pln_angle) :


### PR DESCRIPTION
For details see Issue  #33.

Removal of several unused imports and variables in `Cuboid>traslate.py`. Please check that these were not actually supposed to be used somewhere.