### PR TITLE
Raise ValueError instead of exit()

### DIFF
--- a/src/GEOReverse/reverse.py
+++ b/src/GEOReverse/reverse.py
@@ -30,14 +30,17 @@ def reverse(optFile='configRevese.ini') :
    UnivCell = CADCell()
    UnivCell.shape = UnivCell.makeBox(FreeCAD.BoundBox(*outBox))
 
-#get geometry definition from MCNP input
+   # get geometry definition from MCNP input
    if inFormat == 'mcnp':
       geom = MCNPinput(geomfile)
    elif inFormat == 'openMC_XML':
       geom = XMLinput(geomfile)
    else:
-      print('input format type {} not supported'.format(inFormat))
-      exit()
+      msg = (
+         f'input format type {inFormat} is not supported.'
+         'Supported options are "mcnp" or "openMC_XML"'
+      )
+      raise ValueError(msg)
 
    CADCells,fails = buildCAD(UnivCell,geom,CADselection)
 


### PR DESCRIPTION
Hi

I was just reading the code and though this ```exit``` could be replaced with a ValueError.

This is useful as we can catch and therefore test these ValueErrors and the error message is more informative for the user as it lets them know what the acceptable options are.

All the best

Jon