### PR TITLE
added windows conda install

### DIFF
--- a/docs/install/install_windows.rst
+++ b/docs/install/install_windows.rst
@@ -7,7 +7,7 @@ User install with Mamba (recommended)
 
 First we need to install a Mamba distribution. There are a few options but here we opt for Miniforge3 as it includes Mamba.
 
-You can follow the install instructions for `Miniforge3 here <https://github.com/conda-forge/miniforge>`_ or follows the commands below.
+You can follow the install instructions for `Miniforge3 here <https://github.com/conda-forge/miniforge>`_ .
 
 Download and execute the Miniforge3 Windows installer
 
@@ -18,7 +18,6 @@ You can get it from the Miniforge3 GitHub repository `here <https://github.com/c
 Follow the prompts and complete the installation process
 
 Open "Miniforge Prompt" which will now be available on your start menu.
-
 
 It is recommended to create a new environment
 
@@ -38,6 +37,59 @@ Install FreeCAD which is the main dependency
 .. code-block:: sh
 
     mamba install -c conda-forge freecad
+
+
+Install GEOUNED with pip, we also prefix this with "python -m" to ensure that pip install uses the correct Python interpreter.
+
+.. code-block:: sh
+
+    python -m pip install geouned
+
+Then you will be able to run import GEOUNED from within Python
+
+.. code-block:: python
+
+    import geouned
+
+You will also be able to use the GEOUNED command line tool
+
+.. code-block:: bash
+
+    geouned_cadtocsg --help
+
+User install with Conda
+~~~~~~~~~~~~~~~~~~~~~~~
+
+First we need to install a Conda distribution. There are a few options but we here we opt for `MiniConda3 <https://docs.anaconda.com/free/miniconda/>`_ as it downloads quicker than the fuller `AnaConda <https://www.anaconda.com/download>`_.
+
+You can follow the install instructions for `MiniConda3 <https://docs.anaconda.com/free/miniconda/>`_ 
+
+Download and execute the Miniforge3 Windows installer
+
+You can get it from the Miniforge3 GitHub repository `here <https://docs.anaconda.com/free/miniconda/>`_ or from the link below
+
+`https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_
+
+Open "Anaconda Prompt (miniconda3)" which will now be available on your start menu.
+
+It is recommended to create a new environment
+
+.. code-block:: sh
+
+    conda create --name new_env python=3.11
+
+Activate the new environment
+
+.. code-block:: sh
+
+    conda activate new_env
+
+We have aspirations to create a conda-forge package which will combine these final two steps, but for now FreeCAD and GEOUNED can be installed in two commands.
+Install FreeCAD which is the main dependency
+
+.. code-block:: sh
+
+    conda install -c conda-forge freecad
 
 
 Install GEOUNED with pip, we also prefix this with "python -m" to ensure that pip install uses the correct Python interpreter.


### PR DESCRIPTION
# Description

This adds more install instructions , this time for windows with conda.

now we have both windows and linux with conda and mamba

I should also mention that the install instructions all assume we have a pypi distribution of geouned which we don't currently have but can have with a github release

# Fixes issue

spotted that we are missing this install instructions by @akolsek 

# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [x] I have made corresponding changes to the documentation
