### PR TITLE
added .py to end of cli command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             python -m pip install .
-            geouned_cadtocsg --help
+            geouned_cadtocsg.py --help
             python -c 'import geouned'
             python -c 'from geouned import CadToCsg'
             python -c 'from geouned.GEOReverse import reverse'
@@ -63,8 +63,8 @@ jobs:
         - name: testing GEOUNED functionality
           run: |
             python -m pytest -v tests/test_convert.py
-            geouned_cadtocsg -i tests/config_complete_defaults.json
-            geouned_cadtocsg -i tests/config_non_defaults.json
+            geouned_cadtocsg.py -i tests/config_complete_defaults.json
+            geouned_cadtocsg.py -i tests/config_non_defaults.json
 
         - name: install openmc
           if: ${{ matrix.os == 'ubuntu-latest'}}

--- a/docs/install/install_linux.rst
+++ b/docs/install/install_linux.rst
@@ -65,7 +65,7 @@ You will also be able to use the GEOUNED command line tool
 
 .. code-block:: bash
 
-    geouned_cadtocsg --help
+    geouned_cadtocsg.py --help
 
 User install with Conda
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -131,7 +131,7 @@ You will also be able to use the GEOUNED command line tool
 
 .. code-block:: bash
 
-    geouned_cadtocsg --help
+    geouned_cadtocsg.py --help
 
 
 Developer install with Mamba
@@ -216,7 +216,7 @@ You will also be able to use the GEOUNED command line tool
 
 .. code-block:: bash
 
-    geouned_cadtocsg --help
+    geouned_cadtocsg.py --help
 
 Checkout feature branches from dev and make local changes on you own branch
 

--- a/docs/install/install_windows.rst
+++ b/docs/install/install_windows.rst
@@ -55,7 +55,7 @@ You will also be able to use the GEOUNED command line tool
 
 .. code-block:: bash
 
-    geouned_cadtocsg --help
+    geouned_cadtocsg.py --help
 
 User install with Conda
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -108,4 +108,4 @@ You will also be able to use the GEOUNED command line tool
 
 .. code-block:: bash
 
-    geouned_cadtocsg --help
+    geouned_cadtocsg.py --help

--- a/docs/usage/python_cli_usage.rst
+++ b/docs/usage/python_cli_usage.rst
@@ -19,7 +19,7 @@ Then execute the command line interface tool to convert your STEP file to CSG fi
 
 .. code-block:: bash
 
-    geouned_cadtocsg -i config.json
+    geouned_cadtocsg.py -i config.json
 
 The following example shows a usage with every attributes specified in the config.json file.
 
@@ -112,4 +112,4 @@ This is converted in the same way as the minimal JSON config file
 
 .. code-block:: bash
 
-    geouned_cadtocsg -i config.json
+    geouned_cadtocsg.py -i config.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
 ]
 
 [project.scripts]
-geouned_cadtocsg = "geouned.GEOUNED.scripts.geouned_cadtocsg:main"
+geouned_cadtocsg.py = "geouned.GEOUNED.scripts.geouned_cadtocsg:main"
 
 [tool.black]
 line-length = 128


### PR DESCRIPTION
# Description

Not ready to merge

I've found an issue making a conda forge package when the command line script has no file extension. So this PR changes the command line script to have a .py extension

# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [x] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
