### PR TITLE
Moving decompose logic out of CadToCsg.start to its own method

### DIFF
--- a/src/geouned/GEOUNED/core.py
+++ b/src/geouned/GEOUNED/core.py
@@ -828,6 +828,15 @@ class CadToCsg:
         return warningSolids
 
 
+def update_comment(meta, idLabel):
+    if meta.__commentInfo__ is None:
+        return
+    if meta.__commentInfo__[1] is None:
+        return
+    newLabel = (idLabel[i] for i in meta.__commentInfo__[1])
+    meta.set_comments(void.void_comment_line((meta.__commentInfo__[0], newLabel)))
+
+
 def process_cones(MetaList, cone_info, Surfaces, UniverseBox, options, tolerances, numeric_format):
     cellId = tuple(cone_info.keys())
     for m in MetaList:
@@ -860,15 +869,6 @@ def process_cones(MetaList, cone_info, Surfaces, UniverseBox, options, tolerance
                 tolerances,
                 numeric_format,
             )
-
-
-def update_comment(meta, idLabel):
-    if meta.__commentInfo__ is None:
-        return
-    if meta.__commentInfo__[1] is None:
-        return
-    newLabel = (idLabel[i] for i in meta.__commentInfo__[1])
-    meta.set_comments(void.void_comment_line((meta.__commentInfo__[0], newLabel)))
 
 
 def print_warning_solids(warnSolids, warnEnclosures):


### PR DESCRIPTION
# Description

This PR moves some decomposition logic out of the start method

# Fixes issue

partly helps with #184 and #114

Please link to any issues that this PR fixes

# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [x] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
