### PR TITLE
Added version 1.2 to docs versions

### DIFF
--- a/docs/version_switcher.json
+++ b/docs/version_switcher.json
@@ -8,5 +8,10 @@
         "name": "1.1.0",
         "version": "1.1.0",
         "url": "https://geouned-org.github.io/GEOUNED/1.1.0"
+    },
+    {
+        "name": "1.2.0",
+        "version": "1.2.0",
+        "url": "https://geouned-org.github.io/GEOUNED/1.2.0"
     }
 ]


### PR DESCRIPTION

# Description

This pr adds version 1.2 to docs drop down list for versions . We should merge this after releasing version 1.2

# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [ ] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
