### PR TITLE
moved git tags info from user install into developer install

### DIFF
--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -105,6 +105,19 @@ Checkout feature branches from dev and make local changes on you own branch
 
 Pull requests are welcome
 
+Keeping your fork tags up to date
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Note that your fork of the repository should have releases tags which conform to PEP440 i.e. semantic versioning.
+When installing, setuptools uses these tags to get the version of GEOUNED.
+Release versions in the central repository conform to this standard.
+You can keep the tags in your fork up to date with the main repository using:
+
+.. code-block:: sh
+
+   git fetch --tags https://github.com/GEOUNED-org/GEOUNED
+
+
 Building the docs locally
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -9,17 +9,7 @@ Currently the Mamba / Conda install is the recommended method.
 The main complication when installing GEOUNED is integration between the main dependency (FreeCAD) and the users system Python.
 Mamba / Conda provides a connection between the FreeCAD Python library and your system Python.
 Users have also had success installing FreeCAD and making use of the Python version inbuilt into FreeCAD and the freecad.cmd however the integration of FrreCAD with the system Python is more challenging when installing in this manner.
-.. TODO as well so these installation methods are listed for completeness.
 
-Note that your fork of the repostory must have releases which conform to PEP440 i.e. semantic versioning. When installing, setuptools
-uses these tags to get the release number of GEOUNED. Release versions in the central repository now conform to this standard and can be reflected in your
-fork using:
-
-.. code-block:: sh
-
-   git fetch --tags upstream
-
-where upstream is the remote url of the original repository.
 
 .. toctree::
    :numbered:


### PR DESCRIPTION
# Description

This PR moves some text from the user install into the developer install section of the docs. Also fixed a typo and added the repo url as the upstream. I believe this should be in the developer install instructions instead of the user install as it is only related to installing via github and unrelated to the conda install

# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [ ] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
