### PR TITLE
Update version_switcher.json to include 1.3 and 1.4

### DIFF
--- a/docs/version_switcher.json
+++ b/docs/version_switcher.json
@@ -13,5 +13,15 @@
         "name": "1.2.0",
         "version": "1.2.0",
         "url": "https://geouned-org.github.io/GEOUNED/1.2.0"
+    },
+    {
+        "name": "1.3.0",
+        "version": "1.3.0",
+        "url": "https://geouned-org.github.io/GEOUNED/1.3.0"
+    },
+    {
+        "name": "1.4.0",
+        "version": "1.4.0",
+        "url": "https://geouned-org.github.io/GEOUNED/1.4.0"
     }
 ]


### PR DESCRIPTION
This PR brings the docs up to date with the two releases that are not available in the online docs.

The drop down version number on the docs website should update once this is merged to show versions 1.3.0 and 1.4.0

