### PR TITLE
Fixing index error bug with forcenooverlaps

### DIFF
--- a/src/geouned/GEOUNED/conversion/cell_definition.py
+++ b/src/geouned/GEOUNED/conversion/cell_definition.py
@@ -894,6 +894,10 @@ def no_overlapping_cell(metaList, surfaces, options):
                     comp.clean()
 
             m.set_definition(new_def)
+            for i in range(len(m.Definition.elements)):
+                if type(m.Definition.elements[i].elements) is bool:
+                    logger.info(f"Removed a Solid {i} from cell {m.__id__}")
+                    m.Solids.pop(i)
             m.Definition.join_operators()
             m.Definition.level_update()
 

--- a/src/geouned/GEOUNED/conversion/cell_definition.py
+++ b/src/geouned/GEOUNED/conversion/cell_definition.py
@@ -896,8 +896,9 @@ def no_overlapping_cell(metaList, surfaces, options):
             m.set_definition(new_def)
             for i in range(len(m.Definition.elements)):
                 if type(m.Definition.elements[i].elements) is bool:
-                    logger.info(f"Removed a Solid {i} from cell {m.__id__}")
-                    m.Solids.pop(i)
+                    if not m.Definition.elements[i].elements and m.Definition.operator == "OR":
+                        logger.info(f"Removed a Solid {i} from cell {m.__id__}")
+                        m.Solids.pop(i)
             m.Definition.join_operators()
             m.Definition.level_update()
 


### PR DESCRIPTION
# Description

This pull request adds a check for any bool found in the m.Definition.elements list that gets deleted during the m.Definition.join_operators() call in the cell_definition.py file. 

# Fixes issue

#322

# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [x] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
