### PR TITLE
bug csg_to_CAD openMC. Append method in Set instance

### DIFF
--- a/src/geouned/GEOReverse/Modules/XMLinput.py
+++ b/src/geouned/GEOReverse/Modules/XMLinput.py
@@ -85,7 +85,7 @@ class XmlInput:
 
             if c.FILL:
                 containers.append(c)
-                containers_label.append(c.FILL)
+                containers_label.add(c.FILL)
 
         if 0 in Universe_dict.keys():
             root_universe = 0


### PR DESCRIPTION
Error in CSG to CAD conversion when openMC file with FILL card are converted.

Append method was used in Set instance.

# Fixes issue #328 