### PR TITLE
Change return type from tuple to set in get_surfaces_numbers

### DIFF
--- a/src/geouned/GEOUNED/utils/boolean_function.py
+++ b/src/geouned/GEOUNED/utils/boolean_function.py
@@ -624,7 +624,7 @@ class BoolSequence:
     def get_surfaces_numbers(self):
         """Return the list of all surfaces in the BoolSequence definition."""
         if type(self.elements) is bool:
-            return tuple()
+            return set()
         surf = set()
         for e in self.elements:
             if type(e) is int:


### PR DESCRIPTION
The returned type of the function must be "set" not "tuple".  Bug may produce error during the cell definition simplification, when "simplify" option is turned on.