### PR TITLE
Fix bug: Broaden early return condition in remove_extra_surfaces

### DIFF
--- a/src/geouned/GEOUNED/utils/boolean_solids.py
+++ b/src/geouned/GEOUNED/utils/boolean_solids.py
@@ -321,7 +321,7 @@ def remove_extra_surfaces(CellSeq, CTable):
 
     # Loop over all compound solids of the metaSolid
 
-    if CellSeq.level == 0 and len(CellSeq.elements) == 1:
+    if CellSeq.level == 0:
         return CellSeq
 
     if CellSeq.operator == "AND":


### PR DESCRIPTION
# Description

In the file boolean_solids.py, function remove_extra_surfaces, the following early return code

```
if CellSeq.level == 0 and len(CellSeq.elements) == 1:
        return CellSeq
```

is changed to 

```
if CellSeq.level == 0:
        return CellSeq
```

# Fixes issue

This fixes a rare error where a simple, non-Boolean solid is passed to remove_extra_surfaces but the length of elements is not one.

# Checklist

- [X] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [X] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [N/A] I have made corresponding changes to the documentation -- no documentation update needed
- [N/A] I have added tests that prove my fix is effective or that my feature works -- manually tested using PSI's MUH3 beamline model
