### PR TITLE
feat: oblique torus support in MCNP and OpenMC output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,10 @@ docs/jupyter_execute
 
 # setuptools_scm dynamic version file
 src/_version.py
+
+# project-management & tooling artifacts
+.pm-project.json
+.pm-project
+graph/
+schedule/
+output/

--- a/src/geouned/GEOUNED/utils/data_classes.py
+++ b/src/geouned/GEOUNED/utils/data_classes.py
@@ -45,6 +45,10 @@ class Options:
         forceNoOverlap (bool, optional): force no overlaping cell
             definition. Adjacent cell definition are rested from current
             cell definition. Defaults to False.
+        obliqueTorusStrategy (str, optional): Strategy for oblique torus
+            surfaces in MCNP output. "tr" emits TZ with surface-side TR
+            card; "gq_fallback" emits GQ quadric approximation. Defaults
+            to "tr".
     """
 
     def __init__(
@@ -60,6 +64,7 @@ class Options:
         Facets: bool = False,
         prnt3PPlane: bool = False,
         forceNoOverlap: bool = False,
+        obliqueTorusStrategy: str = "tr",
     ):
 
         self.forceCylinder = forceCylinder
@@ -73,6 +78,7 @@ class Options:
         self.Facets = Facets
         self.prnt3PPlane = prnt3PPlane
         self.forceNoOverlap = forceNoOverlap
+        self.obliqueTorusStrategy = obliqueTorusStrategy
 
     @property
     def forceCylinder(self):
@@ -187,6 +193,23 @@ class Options:
         if not isinstance(value, bool):
             raise TypeError(f"geouned.Options.forceNoOverlap should be a bool, not a {type(value)}")
         self._forceNoOverlap = value
+
+    @property
+    def obliqueTorusStrategy(self):
+        return self._obliqueTorusStrategy
+
+    @obliqueTorusStrategy.setter
+    def obliqueTorusStrategy(self, value: str):
+        allowed = ("tr", "gq_fallback")
+        if not isinstance(value, str):
+            raise TypeError(
+                f"geouned.Options.obliqueTorusStrategy should be a str, not a {type(value)}"
+            )
+        if value not in allowed:
+            raise ValueError(
+                f"geouned.Options.obliqueTorusStrategy must be one of {allowed}, not '{value}'"
+            )
+        self._obliqueTorusStrategy = value
 
 
 class Tolerances:
@@ -414,6 +437,8 @@ class NumericFormat:
         GQ_1to6 (str, optional): GQ 1 to 6 coefficients (order 2 x2,y2,z2,xy,...). Defaults to "18.15f".
         GQ_7to9 (str, optional): GQ 7 to 9 coefficients (order 1 x,y,z). Defaults to "18.15f".
         GQ_10 (str, optional): GQ 10 coefficient. Defaults to "18.15f".
+        TR_o (str, optional): TR card origin coordinates format. Defaults to "14.7e".
+        TR_cos (str, optional): TR card direction cosines format. Defaults to "20.15e".
     """
 
     def __init__(
@@ -432,6 +457,8 @@ class NumericFormat:
         GQ_1to6: str = "18.15f",
         GQ_7to9: str = "18.15f",
         GQ_10: str = "18.15f",
+        TR_o: str = "14.7e",
+        TR_cos: str = "20.15e",
     ):
 
         self.P_abc = P_abc
@@ -448,6 +475,8 @@ class NumericFormat:
         self.GQ_1to6 = GQ_1to6
         self.GQ_7to9 = GQ_7to9
         self.GQ_10 = GQ_10
+        self.TR_o = TR_o
+        self.TR_cos = TR_cos
 
     @property
     def P_abc(self):
@@ -588,6 +617,26 @@ class NumericFormat:
         if not isinstance(GQ_10, str):
             raise TypeError(f"geouned.Tolerances.GQ_10 should be a str, not a {type(GQ_10)}")
         self._GQ_10 = GQ_10
+
+    @property
+    def TR_o(self):
+        return self._TR_o
+
+    @TR_o.setter
+    def TR_o(self, TR_o: str):
+        if not isinstance(TR_o, str):
+            raise TypeError(f"geouned.NumericFormat.TR_o should be a str, not a {type(TR_o)}")
+        self._TR_o = TR_o
+
+    @property
+    def TR_cos(self):
+        return self._TR_cos
+
+    @TR_cos.setter
+    def TR_cos(self, TR_cos: str):
+        if not isinstance(TR_cos, str):
+            raise TypeError(f"geouned.NumericFormat.TR_cos should be a str, not a {type(TR_cos)}")
+        self._TR_cos = TR_cos
 
 
 class Settings:

--- a/src/geouned/GEOUNED/write/functions.py
+++ b/src/geouned/GEOUNED/write/functions.py
@@ -5,7 +5,10 @@ import FreeCAD
 
 from ..utils import q_form as q_form
 from ..utils.basic_functions_part1 import is_opposite, is_parallel
+from .oblique_torus_tr import ObliqueTorusRegistry
 from .string_functions import remove_redundant
+
+logger = __import__("logging").getLogger("general_logger")
 
 
 class CardLine:
@@ -238,7 +241,7 @@ def write_sequence_omc_py(seq, options, prefix="S"):
     return line
 
 
-def mcnp_surface(id, Type, surf, options, tolerances, numeric_format):
+def mcnp_surface(id, Type, surf, options, tolerances, numeric_format, oblique_torus_registry=None):
     mcnp_def = ""
 
     if Type == "Plane":
@@ -484,6 +487,45 @@ def mcnp_surface(id, Type, surf, options, tolerances, numeric_format):
                 xyz=numeric_format.T_xyz,
                 r=numeric_format.T_r,
             )
+        else:
+            if (options.obliqueTorusStrategy == "tr"
+                    and oblique_torus_registry is not None):
+                # Oblique torus: emit TZ in local frame with surface-side TR
+                tr_id = oblique_torus_registry.register(id, Dir, Pos)
+                mcnp_def = """\
+{:<6d} {:<5d} TZ  {:{xyz}} {:{xyz}} {:{xyz}}
+           {:{r}} {:{r}} {:{r}}""".format(
+                    id,
+                    tr_id,
+                    0.0,
+                    0.0,
+                    0.0,
+                    radMaj,
+                    radMin,
+                    radMin,
+                    xyz=numeric_format.T_xyz,
+                    r=numeric_format.T_r,
+                )
+            else:
+                # Legacy fallback: circumscribed cylinder as GQ quadric (lossy)
+                logger.warning(
+                    f"Surface {id}: oblique torus approximated as GQ cylinder "
+                    f"(axis=({Dir.x:.4f},{Dir.y:.4f},{Dir.z:.4f}), "
+                    f"R_maj={radMaj:.4f}, R_min={radMin:.4f} cm). "
+                    f"Set options.obliqueTorusStrategy='tr' for exact treatment."
+                )
+                Q = q_form.q_form_cyl(Dir, Pos, radMaj + radMin)
+                mcnp_def = """\
+{:<6d} GQ  {v[0]:{aTof}} {v[1]:{aTof}} {v[2]:{aTof}}
+          {v[3]:{aTof}} {v[4]:{aTof}} {v[5]:{aTof}}
+          {v[6]:{gToi}} {v[7]:{gToi}} {v[8]:{gToi}}
+          {v[9]:{j}} """.format(
+                    id,
+                    v=Q,
+                    aTof=numeric_format.GQ_1to6,
+                    gToi=numeric_format.GQ_7to9,
+                    j=numeric_format.GQ_10,
+                )
 
     return trim(mcnp_def, 80)
 
@@ -684,7 +726,41 @@ def open_mc_surface(Type, surf, tolerances, numeric_format, out_xml=True, quadri
         Dir.normalize()
         if surf.Degenerated:
             majRad *= surf.a_sign
-        if out_xml:
+        if is_parallel(Dir, FreeCAD.Vector(1, 0, 0), tolerances.angle):
+            omc_surf = "x-torus" if out_xml else "XTorus"
+        elif is_parallel(Dir, FreeCAD.Vector(0, 1, 0), tolerances.angle):
+            omc_surf = "y-torus" if out_xml else "YTorus"
+        elif is_parallel(Dir, FreeCAD.Vector(0, 0, 1), tolerances.angle):
+            omc_surf = "z-torus" if out_xml else "ZTorus"
+        else:
+            omc_surf = None
+
+        if omc_surf is None:
+            # Oblique torus fallback: OpenMC has no quartic surface type.
+            # Approximate with the circumscribed coaxial cylinder of radius
+            # (majRad + minRad). Lossy — cells using these surfaces should be
+            # reviewed before transport-grade analysis.
+            Q = q_form.q_form_cyl(Dir, Center, majRad + minRad)
+            if out_xml:
+                omc_surf = "quadric"
+                coeffs = (
+                    "{v[0]:{aTof}} {v[1]:{aTof}} {v[2]:{aTof}} "
+                    "{v[3]:{aTof}} {v[4]:{aTof}} {v[5]:{aTof}} "
+                    "{v[6]:{gToi}} {v[7]:{gToi}} {v[8]:{gToi}} "
+                    "{v[9]:{j}}"
+                ).format(
+                    v=Q,
+                    aTof=numeric_format.GQ_1to6,
+                    gToi=numeric_format.GQ_7to9,
+                    j=numeric_format.GQ_10,
+                )
+            else:
+                omc_surf = "Quadric"
+                coeffs = (
+                    "a={v[0]},b={v[1]},c={v[2]},d={v[3]},e={v[4]},"
+                    "f={v[5]},g={v[6]},h={v[7]},j={v[8]},k={v[9]}"
+                ).format(v=Q)
+        elif out_xml:
             coeffs = "{:{xyz}} {:{xyz}} {:{xyz}} {:{r}} {:{r}} {:{r}}".format(
                 Center.x,
                 Center.y,
@@ -697,15 +773,6 @@ def open_mc_surface(Type, surf, tolerances, numeric_format, out_xml=True, quadri
             )
         else:
             coeffs = "x0={},y0={},z0={},r={},r1={},r2={}".format(Center.x, Center.y, Center.z, majRad, minRad, minRad)
-
-        if is_parallel(Dir, FreeCAD.Vector(1, 0, 0), tolerances.angle):
-            omc_surf = "x-torus" if out_xml else "XTorus"
-        elif is_parallel(Dir, FreeCAD.Vector(0, 1, 0), tolerances.angle):
-            omc_surf = "y-torus" if out_xml else "YTorus"
-        elif is_parallel(Dir, FreeCAD.Vector(0, 0, 1), tolerances.angle):
-            omc_surf = "z-torus" if out_xml else "ZTorus"
-        else:
-            omc_surf = None
 
     if out_xml:
         coeffs = " ".join(coeffs.split())

--- a/src/geouned/GEOUNED/write/mcnp_format.py
+++ b/src/geouned/GEOUNED/write/mcnp_format.py
@@ -12,6 +12,7 @@ import FreeCAD
 from ..utils.basic_functions_part1 import is_opposite, points_to_coeffs
 from ..utils.functions import SurfacesDict
 from .functions import CardLine, change_surf_sign, mcnp_surface, write_mcnp_cell_def
+from .oblique_torus_tr import ObliqueTorusRegistry
 
 logger = logging.getLogger("general_logger")
 
@@ -56,6 +57,13 @@ class McnpInput:
         self.simplify_planes(Surfaces)
 
         self.Surfaces = self.sorted_surfaces(Surfaces)
+
+        # Initialize oblique torus TR registry
+        # Start TR numbers above the max surface index to avoid collision
+        max_surf = Surfaces.surfaceNumber + Surfaces.IndexOffset
+        tr_start = max(9900, max_surf + 1000)
+        self.oblique_torus_registry = ObliqueTorusRegistry(tr_start=tr_start)
+
         self.Materials = set()
 
         return
@@ -100,6 +108,15 @@ C ##########################################################
         self.write_surface_block()
         self.inpfile.write(" \n")
         self.write_mat_block()
+
+        # TR cards for oblique tori (data block, before source)
+        tr_block = self.oblique_torus_registry.format_tr_cards(
+            fmt_origin=self.numeric_format.TR_o,
+            fmt_cosine=self.numeric_format.TR_cos,
+        )
+        if tr_block:
+            self.inpfile.write(tr_block)
+ ([Plan: T1.2-oblique-torus-TR] Task 2.2: McnpInput integrate oblique torus registry)
         self.write_source_block()
 
         self.inpfile.close()
@@ -183,6 +200,7 @@ C **************************************************************
             self.options,
             self.tolerances,
             self.numeric_format,
+            oblique_torus_registry=self.oblique_torus_registry,
         )
         if MCNP_def:
             MCNP_def += "\n"

--- a/src/geouned/GEOUNED/write/oblique_torus_tr.py
+++ b/src/geouned/GEOUNED/write/oblique_torus_tr.py
@@ -1,0 +1,195 @@
+"""Oblique torus handling for MCNP writer — surface-side TR card approach."""
+
+import logging
+import math
+
+import FreeCAD
+
+logger = logging.getLogger("general_logger")
+
+
+def build_rotation_matrix(direction: FreeCAD.Vector) -> tuple:
+    """Build orthonormal rotation matrix B such that B @ (0,0,1) = direction.
+
+    Parameters
+    ----------
+    direction : FreeCAD.Vector
+        Unit vector of the torus axis in the global frame.
+        Must be normalized (length ≈ 1).
+
+    Returns
+    -------
+    tuple of 9 floats
+        (b1, b2, b3, b4, b5, b6, b7, b8, b9) — row-major B matrix.
+        Row 1 = local x' in global, Row 2 = local y' in global,
+        Row 3 = local z' in global = direction.
+
+    Raises
+    ------
+    ValueError
+        If direction has near-zero length.
+    """
+    d = FreeCAD.Vector(direction)
+    if d.Length < 1e-12:
+        raise ValueError(f"Torus axis direction has near-zero length: {direction}")
+    d.normalize()
+
+    # z_local = d (the torus axis becomes local z)
+    z_loc = d
+
+    # Choose reference vector for cross product to avoid near-parallel case
+    if abs(d.z) < 0.9:
+        ref = FreeCAD.Vector(0, 0, 1)
+    else:
+        ref = FreeCAD.Vector(0, 1, 0)
+
+    # x_local = normalize(ref × z_local)
+    x_loc = ref.cross(z_loc)
+    x_loc.normalize()
+
+    # y_local = z_local × x_local  (right-handed system)
+    y_loc = z_loc.cross(x_loc)
+    y_loc.normalize()
+
+    # Verify proper rotation (det = +1)
+    det = (
+        x_loc.x * (y_loc.y * z_loc.z - y_loc.z * z_loc.y)
+        - x_loc.y * (y_loc.x * z_loc.z - y_loc.z * z_loc.x)
+        + x_loc.z * (y_loc.x * z_loc.y - y_loc.y * z_loc.x)
+    )
+    if det < 0:
+        # Flip x to get proper rotation
+        x_loc = x_loc * (-1)
+        y_loc = z_loc.cross(x_loc)
+        y_loc.normalize()
+
+    return (
+        x_loc.x, x_loc.y, x_loc.z,
+        y_loc.x, y_loc.y, y_loc.z,
+        z_loc.x, z_loc.y, z_loc.z,
+    )
+
+
+class ObliqueTorusRegistry:
+    """Registry for oblique torus TR cards during MCNP writing.
+
+    Each registered oblique torus produces one TR card. The registry
+    assigns monotonically increasing TR numbers.
+
+    Attributes
+    ----------
+    entries : list of dict
+        Each entry: {
+            "surf_id": int,       # original surface ID
+            "tr_id": int,         # assigned TR card number
+            "origin": (float, float, float),  # torus center in cm (global)
+            "cosines": tuple of 9 floats,     # B matrix row-major
+        }
+    """
+
+    def __init__(self, tr_start: int = 9900):
+        """
+        Parameters
+        ----------
+        tr_start : int
+            First TR card number to assign. Subsequent ones increment by 1.
+        """
+        self._next_tr = tr_start
+        self.entries = []
+
+    @property
+    def next_tr_id(self) -> int:
+        return self._next_tr
+
+    def register(self, surf_id: int, direction: FreeCAD.Vector,
+                 center_cm: FreeCAD.Vector) -> int:
+        """Register an oblique torus and return the assigned TR card number.
+
+        Parameters
+        ----------
+        surf_id : int
+            The GEOUNED surface index for this torus.
+        direction : FreeCAD.Vector
+            Unit axis of the torus (global frame, already normalized).
+        center_cm : FreeCAD.Vector
+            Torus center in cm (already converted from mm).
+
+        Returns
+        -------
+        int
+            The TR card number assigned to this surface.
+        """
+        cosines = build_rotation_matrix(direction)
+        tr_id = self._next_tr
+        self._next_tr += 1
+
+        entry = {
+            "surf_id": surf_id,
+            "tr_id": tr_id,
+            "origin": (center_cm.x, center_cm.y, center_cm.z),
+            "cosines": cosines,
+        }
+        self.entries.append(entry)
+
+        logger.info(
+            f"Oblique torus surface {surf_id}: assigned TR{tr_id}, "
+            f"axis=({direction.x:.6f}, {direction.y:.6f}, {direction.z:.6f}), "
+            f"center=({center_cm.x:.4f}, {center_cm.y:.4f}, {center_cm.z:.4f}) cm"
+        )
+        return tr_id
+
+    def format_tr_cards(self, fmt_origin: str = "14.7e",
+                        fmt_cosine: str = "20.15e") -> str:
+        """Format all registered TR cards as a single MCNP-ready string.
+
+        Parameters
+        ----------
+        fmt_origin : str
+            Python format spec for origin coordinates.
+        fmt_cosine : str
+            Python format spec for direction cosines (need ≥12 sig digits).
+
+        Returns
+        -------
+        str
+            Multi-line string ready to write into MCNP data block.
+            Empty string if no oblique tori registered.
+        """
+        if not self.entries:
+            return ""
+
+        lines = []
+        lines.append("C ")
+        lines.append("C " + "=" * 58)
+        lines.append("C     COORDINATE TRANSFORMATIONS (oblique tori)")
+        lines.append("C " + "=" * 58)
+        lines.append("C ")
+
+        for entry in self.entries:
+            ox, oy, oz = entry["origin"]
+            b = entry["cosines"]
+            tr_id = entry["tr_id"]
+
+            card = "TR{:<5d}".format(tr_id)
+            # Line 1: origin
+            line1 = "{} {:{fo}} {:{fo}} {:{fo}}".format(
+                card, ox, oy, oz, fo=fmt_origin
+            )
+            # Line 2-4: cosines (3 per line)
+            line2 = "{:8s}{:{fc}} {:{fc}} {:{fc}}".format(
+                "", b[0], b[1], b[2], fc=fmt_cosine
+            )
+            line3 = "{:8s}{:{fc}} {:{fc}} {:{fc}}".format(
+                "", b[3], b[4], b[5], fc=fmt_cosine
+            )
+            line4 = "{:8s}{:{fc}} {:{fc}} {:{fc}} 1".format(
+                "", b[6], b[7], b[8], fc=fmt_cosine
+            )
+
+            lines.append(f"C  Surface {entry['surf_id']} oblique torus")
+            lines.append(line1)
+            lines.append(line2)
+            lines.append(line3)
+            lines.append(line4)
+
+        return "\n".join(lines) + "\n"

--- a/tests/test_oblique_torus.py
+++ b/tests/test_oblique_torus.py
@@ -1,0 +1,421 @@
+import math
+import sys
+
+import pytest
+
+# Import the data_classes module directly to avoid the FreeCAD-requiring
+# package __init__.py chain.  Options and NumericFormat are pure Python.
+def _import_data_classes():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "geouned.GEOUNED.utils.data_classes",
+        "src/geouned/GEOUNED/utils/data_classes.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["geouned.GEOUNED.utils.data_classes"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_data_classes = _import_data_classes()
+Options = _data_classes.Options
+NumericFormat = _data_classes.NumericFormat
+
+try:
+    import FreeCAD
+    import Part
+
+    HAS_FREECAD = True
+except ImportError:
+    HAS_FREECAD = False
+
+
+# ---------------------------------------------------------------------------
+# Options & NumericFormat (no FreeCAD needed)
+# ---------------------------------------------------------------------------
+
+
+class TestObliqueTorusOptions:
+
+    def test_default_strategy_is_tr(self):
+        options = Options()
+        assert options.obliqueTorusStrategy == "tr"
+
+    def test_set_strategy_gq_fallback(self):
+        options = Options(obliqueTorusStrategy="gq_fallback")
+        assert options.obliqueTorusStrategy == "gq_fallback"
+
+    def test_set_strategy_tr_explicit(self):
+        options = Options(obliqueTorusStrategy="tr")
+        assert options.obliqueTorusStrategy == "tr"
+
+    def test_invalid_strategy_raises_value_error(self):
+        with pytest.raises(ValueError, match="obliqueTorusStrategy"):
+            Options(obliqueTorusStrategy="invalid")
+
+    def test_non_string_strategy_raises_type_error(self):
+        with pytest.raises(TypeError, match="obliqueTorusStrategy"):
+            Options(obliqueTorusStrategy=123)
+
+    def test_strategy_setter_validation(self):
+        options = Options()
+        options.obliqueTorusStrategy = "gq_fallback"
+        assert options.obliqueTorusStrategy == "gq_fallback"
+        options.obliqueTorusStrategy = "tr"
+        assert options.obliqueTorusStrategy == "tr"
+        with pytest.raises(ValueError):
+            options.obliqueTorusStrategy = "bad_value"
+
+
+class TestNumericFormatTRFields:
+
+    def test_default_tr_o(self):
+        nf = NumericFormat()
+        assert nf.TR_o == "14.7e"
+
+    def test_default_tr_cos(self):
+        nf = NumericFormat()
+        assert nf.TR_cos == "20.15e"
+
+    def test_custom_tr_o(self):
+        nf = NumericFormat(TR_o="12.5e")
+        assert nf.TR_o == "12.5e"
+
+    def test_custom_tr_cos(self):
+        nf = NumericFormat(TR_cos="18.12e")
+        assert nf.TR_cos == "18.12e"
+
+    def test_tr_o_type_check(self):
+        nf = NumericFormat()
+        with pytest.raises(TypeError, match="TR_o"):
+            nf.TR_o = 123
+
+    def test_tr_cos_type_check(self):
+        nf = NumericFormat()
+        with pytest.raises(TypeError, match="TR_cos"):
+            nf.TR_cos = 456
+
+
+# ---------------------------------------------------------------------------
+# build_rotation_matrix (FreeCAD required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not HAS_FREECAD, reason="FreeCAD not available in this environment")
+class TestBuildRotationMatrix:
+
+    def test_axis_aligned_x(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import build_rotation_matrix
+
+        direction = FreeCAD.Vector(1, 0, 0)
+        b = build_rotation_matrix(direction)
+        assert len(b) == 9
+        self._assert_orthonormal(b)
+        self._assert_proper_rotation(b)
+        self._assert_row3_matches_direction(b, direction)
+
+    def test_axis_aligned_y(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import build_rotation_matrix
+
+        direction = FreeCAD.Vector(0, 1, 0)
+        b = build_rotation_matrix(direction)
+        self._assert_orthonormal(b)
+        self._assert_proper_rotation(b)
+        self._assert_row3_matches_direction(b, direction)
+
+    def test_axis_aligned_z(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import build_rotation_matrix
+
+        direction = FreeCAD.Vector(0, 0, 1)
+        b = build_rotation_matrix(direction)
+        self._assert_orthonormal(b)
+        self._assert_proper_rotation(b)
+        self._assert_row3_matches_direction(b, direction)
+
+    def test_oblique_diagonal(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import build_rotation_matrix
+
+        direction = FreeCAD.Vector(1, 1, 1)
+        b = build_rotation_matrix(direction)
+        self._assert_orthonormal(b)
+        self._assert_proper_rotation(b)
+        self._assert_row3_matches_direction(b, direction)
+
+    def test_oblique_arbitrary(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import build_rotation_matrix
+
+        direction = FreeCAD.Vector(0.577350269, 0.577350269, 0.577350269)
+        b = build_rotation_matrix(direction)
+        self._assert_orthonormal(b)
+        self._assert_proper_rotation(b)
+        self._assert_row3_matches_direction(b, direction)
+
+    def test_near_parallel_z_positive(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import build_rotation_matrix
+
+        direction = FreeCAD.Vector(0.01, 0.02, 0.9998)
+        b = build_rotation_matrix(direction)
+        self._assert_orthonormal(b)
+        self._assert_proper_rotation(b)
+        self._assert_row3_matches_direction(b, direction)
+
+    def test_near_parallel_z_negative(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import build_rotation_matrix
+
+        direction = FreeCAD.Vector(0.01, 0.02, -0.9998)
+        b = build_rotation_matrix(direction)
+        self._assert_orthonormal(b)
+        self._assert_proper_rotation(b)
+        self._assert_row3_matches_direction(b, direction)
+
+    def test_zero_length_raises_value_error(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import build_rotation_matrix
+
+        direction = FreeCAD.Vector(0, 0, 0)
+        with pytest.raises(ValueError, match="near-zero length"):
+            build_rotation_matrix(direction)
+
+    def test_very_small_direction_raises_value_error(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import build_rotation_matrix
+
+        direction = FreeCAD.Vector(1e-14, 0, 0)
+        with pytest.raises(ValueError, match="near-zero length"):
+            build_rotation_matrix(direction)
+
+    def test_negated_direction_is_still_proper(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import build_rotation_matrix
+
+        direction = FreeCAD.Vector(-1, -2, -3)
+        b = build_rotation_matrix(direction)
+        self._assert_orthonormal(b)
+        self._assert_proper_rotation(b)
+        self._assert_row3_matches_direction(b, direction)
+
+    # -- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _assert_orthonormal(b):
+        def _row(i):
+            return FreeCAD.Vector(b[i * 3], b[i * 3 + 1], b[i * 3 + 2])
+
+        r0 = _row(0)
+        r1 = _row(1)
+        r2 = _row(2)
+        assert math.isclose(r0.Length, 1.0, abs_tol=1e-12), f"row 0 not unit: {r0.Length}"
+        assert math.isclose(r1.Length, 1.0, abs_tol=1e-12), f"row 1 not unit: {r1.Length}"
+        assert math.isclose(r2.Length, 1.0, abs_tol=1e-12), f"row 2 not unit: {r2.Length}"
+        assert math.isclose(r0.dot(r1), 0.0, abs_tol=1e-12), f"row 0·1 not orthogonal: {r0.dot(r1)}"
+        assert math.isclose(r1.dot(r2), 0.0, abs_tol=1e-12), f"row 1·2 not orthogonal: {r1.dot(r2)}"
+        assert math.isclose(r2.dot(r0), 0.0, abs_tol=1e-12), f"row 2·0 not orthogonal: {r2.dot(r0)}"
+
+    @staticmethod
+    def _assert_proper_rotation(b):
+        det = (
+            b[0] * (b[4] * b[8] - b[5] * b[7])
+            - b[1] * (b[3] * b[8] - b[5] * b[6])
+            + b[2] * (b[3] * b[7] - b[4] * b[6])
+        )
+        assert math.isclose(det, 1.0, abs_tol=1e-12), f"determinant {det} ≠ 1"
+
+    @staticmethod
+    def _assert_row3_matches_direction(b, direction):
+        expected = FreeCAD.Vector(direction).normalize()
+        row3 = FreeCAD.Vector(b[6], b[7], b[8])
+        assert row3.isEqual(expected, 1e-12), f"row3 {row3} ≠ direction {expected}"
+
+
+# ---------------------------------------------------------------------------
+# ObliqueTorusRegistry (FreeCAD required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not HAS_FREECAD, reason="FreeCAD not available in this environment")
+class TestObliqueTorusRegistry:
+
+    def test_default_constructor(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import ObliqueTorusRegistry
+
+        reg = ObliqueTorusRegistry()
+        assert reg.next_tr_id == 9900
+        assert reg.entries == []
+
+    def test_custom_tr_start(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import ObliqueTorusRegistry
+
+        reg = ObliqueTorusRegistry(tr_start=5000)
+        assert reg.next_tr_id == 5000
+
+    def test_register_returns_monotonic_ids(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import ObliqueTorusRegistry
+
+        reg = ObliqueTorusRegistry(tr_start=100)
+        id1 = reg.register(10, FreeCAD.Vector(1, 0, 0), FreeCAD.Vector(0, 0, 0))
+        id2 = reg.register(20, FreeCAD.Vector(0, 1, 0), FreeCAD.Vector(1, 2, 3))
+        id3 = reg.register(30, FreeCAD.Vector(0, 0, 1), FreeCAD.Vector(4, 5, 6))
+        assert id1 == 100
+        assert id2 == 101
+        assert id3 == 102
+        assert reg.next_tr_id == 103
+
+    def test_register_entry_structure(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import ObliqueTorusRegistry
+
+        reg = ObliqueTorusRegistry(tr_start=1)
+        direction = FreeCAD.Vector(3, 0, 0)
+        center = FreeCAD.Vector(10, 20, 30)
+        tid = reg.register(99, direction, center)
+        assert tid == 1
+        entry = reg.entries[0]
+        assert entry["surf_id"] == 99
+        assert entry["tr_id"] == 1
+        assert entry["origin"] == (10.0, 20.0, 30.0)
+        assert len(entry["cosines"]) == 9
+
+    def test_format_tr_cards_empty(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import ObliqueTorusRegistry
+
+        reg = ObliqueTorusRegistry()
+        output = reg.format_tr_cards()
+        assert output == ""
+
+    def test_format_tr_cards_single_entry(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import ObliqueTorusRegistry
+
+        reg = ObliqueTorusRegistry(tr_start=1)
+        reg.register(100, FreeCAD.Vector(0, 0, 1), FreeCAD.Vector(0, 0, 0))
+        output = reg.format_tr_cards()
+        assert "TR1" in output
+        assert "oblique tori" in output
+        assert "Surface 100" in output
+
+    def test_format_tr_cards_multiple_entries(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import ObliqueTorusRegistry
+
+        reg = ObliqueTorusRegistry(tr_start=1)
+        reg.register(100, FreeCAD.Vector(0, 0, 1), FreeCAD.Vector(0, 0, 0))
+        reg.register(200, FreeCAD.Vector(1, 0, 0), FreeCAD.Vector(5, 5, 5))
+        reg.register(300, FreeCAD.Vector(0, 1, 0), FreeCAD.Vector(-1, -1, -1))
+        output = reg.format_tr_cards()
+        assert "TR1" in output
+        assert "TR2" in output
+        assert "TR3" in output
+        assert "Surface 100" in output
+        assert "Surface 200" in output
+        assert "Surface 300" in output
+
+    def test_format_tr_cards_numbering_continues_after_registration(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import ObliqueTorusRegistry
+
+        reg = ObliqueTorusRegistry(tr_start=1)
+        reg.register(10, FreeCAD.Vector(0, 0, 1), FreeCAD.Vector(0, 0, 0))
+        output = reg.format_tr_cards()
+        assert "TR1" in output
+        assert "TR2" not in output
+
+    def test_register_cosines_match_build_rotation_matrix(self):
+        from geouned.GEOUNED.write.oblique_torus_tr import ObliqueTorusRegistry, build_rotation_matrix
+
+        direction = FreeCAD.Vector(1, 2, 3)
+        reg = ObliqueTorusRegistry(tr_start=1)
+        reg.register(50, direction, FreeCAD.Vector(0, 0, 0))
+        expected = build_rotation_matrix(direction)
+        actual = reg.entries[0]["cosines"]
+        for i in range(9):
+            assert math.isclose(actual[i], expected[i], abs_tol=1e-12), f"index {i}: {actual[i]} ≠ {expected[i]}"
+
+
+# ---------------------------------------------------------------------------
+# GQ quadric fallback — oblique torus → circumscribed cylinder (FreeCAD required)
+# ---------------------------------------------------------------------------
+
+
+def _make_torus_surface(axis, center, major_r, minor_r):
+    axis = FreeCAD.Vector(axis)
+    axis.normalize()
+    p = Part.makeTorus(major_r, minor_r, FreeCAD.Vector(0, 0, 0), axis, 360)
+    p.translate(center)
+    face = p.Faces[0]
+    from geouned.GEOUNED.utils.geometry_gu import getSurface
+
+    surf = getSurface(face)
+    surf.MajorRadius = major_r
+    surf.MinorRadius = minor_r
+    return surf
+
+
+@pytest.mark.skipif(not HAS_FREECAD, reason="FreeCAD not available in this environment")
+class TestObliqueTorusGQFallback:
+
+    def test_oblique_torus_omc_surface_is_quadric_not_none(self):
+        from geouned.GEOUNED.utils.data_classes import NumericFormat, Tolerances
+        from geouned.GEOUNED.write.functions import open_mc_surface
+
+        surf = _make_torus_surface(FreeCAD.Vector(1, 1, 1), FreeCAD.Vector(0, 0, 0), 4, 1)
+        omc_type, coeffs = open_mc_surface("Torus", surf, Tolerances(), NumericFormat())
+        assert omc_type == "quadric"
+        assert coeffs
+
+    def test_oblique_torus_omc_coeffs_ten_tokens(self):
+        from geouned.GEOUNED.utils.data_classes import NumericFormat, Tolerances
+        from geouned.GEOUNED.write.functions import open_mc_surface
+
+        surf = _make_torus_surface(FreeCAD.Vector(1, 1, 1), FreeCAD.Vector(0, 0, 0), 4, 1)
+        _, coeffs = open_mc_surface("Torus", surf, Tolerances(), NumericFormat())
+        assert len(coeffs.split()) == 10
+
+    def test_oblique_torus_mcnp_gq_fallback(self):
+        from geouned.GEOUNED.utils.data_classes import NumericFormat, Options, Tolerances
+        from geouned.GEOUNED.write.functions import mcnp_surface
+
+        surf = _make_torus_surface(FreeCAD.Vector(1, 1, 1), FreeCAD.Vector(0, 0, 0), 4, 1)
+        options = Options(obliqueTorusStrategy="gq_fallback")
+        result = mcnp_surface(10, "Torus", surf, options, Tolerances(), NumericFormat())
+        assert "GQ" in result
+
+    def test_oblique_torus_mcnp_tr_strategy(self):
+        from geouned.GEOUNED.utils.data_classes import NumericFormat, Options, Tolerances
+        from geouned.GEOUNED.write.functions import mcnp_surface
+        from geouned.GEOUNED.write.oblique_torus_tr import ObliqueTorusRegistry
+
+        surf = _make_torus_surface(FreeCAD.Vector(1, 1, 1), FreeCAD.Vector(0, 0, 0), 4, 1)
+        options = Options(obliqueTorusStrategy="tr")
+        reg = ObliqueTorusRegistry(tr_start=9900)
+        result = mcnp_surface(10, "Torus", surf, options, Tolerances(), NumericFormat(), reg)
+        assert "TZ" in result
+        assert "9900" in result
+        assert len(reg.entries) == 1
+
+    def test_oblique_torus_mcnp_tr_strategy_no_registry_falls_back_to_gq(self):
+        from geouned.GEOUNED.utils.data_classes import NumericFormat, Options, Tolerances
+        from geouned.GEOUNED.write.functions import mcnp_surface
+
+        surf = _make_torus_surface(FreeCAD.Vector(1, 1, 1), FreeCAD.Vector(0, 0, 0), 4, 1)
+        options = Options(obliqueTorusStrategy="tr")
+        result = mcnp_surface(10, "Torus", surf, options, Tolerances(), NumericFormat())
+        assert "GQ" in result
+
+    def test_axis_aligned_torus_still_works_omc(self):
+        from geouned.GEOUNED.utils.data_classes import NumericFormat, Tolerances
+        from geouned.GEOUNED.write.functions import open_mc_surface
+
+        for axis in (FreeCAD.Vector(1, 0, 0), FreeCAD.Vector(0, 1, 0), FreeCAD.Vector(0, 0, 1)):
+            surf = _make_torus_surface(axis, FreeCAD.Vector(0, 0, 0), 4, 1)
+            omc_type, coeffs = open_mc_surface("Torus", surf, Tolerances(), NumericFormat())
+            assert omc_type in ("x-torus", "y-torus", "z-torus")
+            assert coeffs
+            assert "quadric" not in omc_type
+
+    def test_axis_aligned_torus_still_works_mcnp(self):
+        from geouned.GEOUNED.utils.data_classes import NumericFormat, Options, Tolerances
+        from geouned.GEOUNED.write.functions import mcnp_surface
+
+        for axis, card in (
+            (FreeCAD.Vector(1, 0, 0), "TX"),
+            (FreeCAD.Vector(0, 1, 0), "TY"),
+            (FreeCAD.Vector(0, 0, 1), "TZ"),
+        ):
+            surf = _make_torus_surface(axis, FreeCAD.Vector(0, 0, 0), 4, 1)
+            result = mcnp_surface(10, "Torus", surf, Options(), Tolerances(), NumericFormat())
+            assert card in result
+            assert "GQ" not in result


### PR DESCRIPTION
## Summary

This PR adds support for **oblique-axis tori** (tori whose symmetry axis is not aligned with X, Y, or Z) in both **MCNP** and **OpenMC** output formats. Previously, GEOUNED silently dropped oblique torus surfaces, leaving cells with `None` surface references.

## Motivation

GEOUNED's torus surface writers (`TX`, `TY`, `TZ` in MCNP; `x-torus`, `y-torus`, `z-torus` in OpenMC) require axis-aligned tori. Any torus with an oblique axis was either incorrectly written or silently dropped. This is a real issue for CAD models that include toroidal surfaces in arbitrary orientations (e.g., ITER-like vacuum vessel ports, divertor cooling pipes at angles).

## Approach

Two strategies are provided:

### 1. GQ Quadric Fallback (OpenMC)
OpenMC has no native quartic surface type, so oblique tori are approximated by a **circumscribed coaxial cylinder** of radius `R_maj + R_min`, emitted as a GQ quadric. Conservative (lossy) — cells using these surfaces should be reviewed before transport-grade analysis.

### 2. MCNP TR Card Approach (exact)
MCNP's `TR` transformation cards allow exact representation. The approach:
- Register oblique tori in an `ObliqueTorusRegistry` during surface writing
- Emit a `TZ` torus at the origin with a surface-side `TR` card that rotates the coordinate system
- `build_rotation_matrix()` constructs a **proper rotation matrix** (orthonormal, det=+1) from the torus axis direction

The strategy is selectable via `Options.obliqueTorusStrategy`:
- `"tr"` (default) — exact TR card treatment
- `"gq_fallback"` — circumscribed-cylinder GQ approximation

## Changes

### New files
- [`oblique_torus_tr.py`](https://github.com/zxkjack123/GEOUNED/blob/feature/oblique-torus-tr/src/geouned/GEOUNED/write/oblique_torus_tr.py) — `ObliqueTorusRegistry` class + `build_rotation_matrix()` (195 lines)
- [`test_oblique_torus.py`](https://github.com/zxkjack123/GEOUNED/blob/feature/oblique-torus-tr/tests/test_oblique_torus.py) — 38 unit tests (421 lines)

### Modified files
- `data_classes.py` — `NumericFormat.TR_o` / `TR_cos` format fields; `Options.obliqueTorusStrategy` with validation
- `functions.py` — `mcnp_surface()`: TR path for oblique tori; `open_mc_surface()`: GQ quadric fallback
- `mcnp_format.py` — `McnpInput`: integrates `ObliqueTorusRegistry`, emits TR card block before source block

### ⚠️ .gitignore changes included
The first commit (`f4ba24d`) also added `.gitignore` entries for project-management tooling artifacts. If these .gitignore changes are not desired, I can remove them from this PR.

## Backward Compatibility

- **Axis-aligned TX/TY/TZ paths are unchanged** for all code variants
- Both `mcnp_surface()` and `open_mc_surface()` signatures are backward compatible
- Default `obliqueTorusStrategy="tr"` — existing models without oblique tori see zero change

## Testing

38 new unit tests covering:
- `build_rotation_matrix()` — orthonormality, determinant=+1, row3=direction, error handling
- `ObliqueTorusRegistry` — monotonic IDs, formatting, cosines consistency
- GQ fallback — quadric output correctness, 10-token coefficients, regression for axis-aligned tori
- `Options` / `NumericFormat` — defaults, validation, type checking

Tests gracefully skip when FreeCAD is unavailable (12 pass in non-FreeCAD environments).